### PR TITLE
Update code block highlighting in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ $ npm install photon-colors
 
 #### Sass
 
-```Sass
+```scss
 @import "photon-colors.scss";
 
 .class_name {


### PR DESCRIPTION
Hi! This is a really small change to the readme. 

The code block in the readme was tagged with `sass`, which meant it was highlighting the code as if it was Sass not SCSS. 

Changing it to `scss` stopped it from highlighting the semicolons as errors.